### PR TITLE
Update manage-database-copies.md

### DIFF
--- a/Exchange/ExchangeServer/high-availability/manage-ha/manage-database-copies.md
+++ b/Exchange/ExchangeServer/high-availability/manage-ha/manage-database-copies.md
@@ -197,13 +197,15 @@ In Exchange 2016, log truncation doesn't occur on an active mailbox database cop
   
  Exchange 2016 now has a feature called *loose truncation* that is disabled by default. During normal operations, each database copy keeps logs that need to be shipped to other database copies until all copies of a database confirm they have replayed (passive copies) or received (lagged copies) the log files. This is default log truncation behavior. If a database copy goes offline for some reason, the log files begin accumulating on the disks used by the other copies of the database. If the affected database copy remains offline for an extended period, this can cause the other database copies to run out of disk space.
   
-Truncation behavior is different when loose truncation is enabled. Each database copy tracks its own free disk space and applies loose truncation behavior if free space gets low.
+Truncation behavior is different when loose truncation and circular logging are enabled. Each database copy tracks its own free disk space and applies loose truncation behavior if free space gets low.
   
 - For the active copy, the oldest straggler (the passive database copy that is farthest behind in log replay) is ignored and truncation respects the oldest remaining passive copies. The active database copy is where global truncation is calculated.
     
 - For a passive copy, if space gets low, it will independently truncate its log files using the configured parameters described later in the Registry Value table.The passive copies will attempt to respect the truncation decision made on the active copy. Despite the implication of the name MinCopiesToProtect, Exchange will only ignore the oldest known straggler at the time truncation is run.
     
 When the offline database is brought back online, it will be missing log files that have been deleted from the other healthy copies, and its database copy status will be FailedAndSuspended. In this event, if Autoreseed is configured, the affected copy will be automatically reseeded. If Autoreseed is not configured, the database copy will need to be manually seeded by an administrator.
+
+If circular logging is disabled, Loose Truncation respects backups if they have been taken, so if logs have not been backed up they will not be removed by Loose Truncation. Loose Truncation is a recommended feature for preferred architecture where backups are not used and circular logging is enabled.
   
 The required number of healthy copies, the free disk space threshold, and the number of logs to keep are all configurable parameters. By default, the free disk space threshold is 204800 MB (200 GB), and the number of logs to keep is 100,000 (100 GB) for passive copies, and 10,000 (10 GB) for active copies.
   

--- a/Exchange/ExchangeServer/high-availability/manage-ha/manage-database-copies.md
+++ b/Exchange/ExchangeServer/high-availability/manage-ha/manage-database-copies.md
@@ -205,7 +205,9 @@ Truncation behavior is different when loose truncation and circular logging are 
     
 When the offline database is brought back online, it will be missing log files that have been deleted from the other healthy copies, and its database copy status will be FailedAndSuspended. In this event, if Autoreseed is configured, the affected copy will be automatically reseeded. If Autoreseed is not configured, the database copy will need to be manually seeded by an administrator.
 
-If circular logging is disabled, Loose Truncation respects backups if they have been taken, so if logs have not been backed up they will not be removed by Loose Truncation. Loose Truncation is a recommended feature for preferred architecture where backups are not used and circular logging is enabled.
+If circular logging is disabled, loose truncation respects backups if they have been taken, so if logs have not been backed up they will not be removed by loose Truncation. 
+
+truncation is a recommended feature for preferred architecture where backups are not used and circular logging is enabled.
   
 The required number of healthy copies, the free disk space threshold, and the number of logs to keep are all configurable parameters. By default, the free disk space threshold is 204800 MB (200 GB), and the number of logs to keep is 100,000 (100 GB) for passive copies, and 10,000 (10 GB) for active copies.
   


### PR DESCRIPTION
Loose truncation is a feature helping to avoid situation when disk space is low in case drives with logs are full so we can remove transaction logs even if they were not replicated to passive copies. 
However, this description doesn't mention that Loose Truncation respects backups and just wont work if logs are not in backup yet. 
This can confuse some customers who are trying to rely on that feature and would prefer to victimize backups in low disk space condition. Added remarkes about that into the article.