### PR TITLE
Add support for users with the same Display Name

### DIFF
--- a/Exchange/ExchangeServer/policy-and-compliance/mailbox-audit-logging/enable-or-disable.md
+++ b/Exchange/ExchangeServer/policy-and-compliance/mailbox-audit-logging/enable-or-disable.md
@@ -52,7 +52,7 @@ Set-Mailbox -Identity "Ben Smith" -AuditEnabled $true
 This example enables mailbox audit logging for all user mailboxes in your organization.
   
 ```
-Get-Mailbox -ResultSize Unlimited -Filter {RecipientTypeDetails -eq "UserMailbox"} | Set-Mailbox -AuditEnabled $true
+Get-Mailbox -ResultSize Unlimited -Filter {RecipientTypeDetails -eq "UserMailbox"} | Select PrimarySmtpAddress | ForEach {Set-Mailbox -Identity $_.PrimarySmtpAddress -AuditEnabled $true}
 ```
 
 This example disables mailbox audit logging for Ben Smith's mailbox.


### PR DESCRIPTION
I'd like to request a possible improvement.

The current example command to enable audit logging only works if you don't have multiple users with the same Display Name.  I have users with multiple accounts with different domain names, as well as shared accounts for info or marketing, so that isn't working for me. 

I've added a part to select the Primary SMTP Address, and use that for then looping through everyone and enabling the auditing. 

Thank you for considering!