### PR TITLE
Add powershell identifier to code blocks

### DIFF
--- a/Exchange/ExchangeOnline/mailbox-migration/migrate-mailboxes-across-tenants.md
+++ b/Exchange/ExchangeOnline/mailbox-migration/migrate-mailboxes-across-tenants.md
@@ -204,14 +204,14 @@ Use the following sample Windows PowerShell scripts as a starting point for crea
     
 3. Use the Windows PowerShell command:
     
-  ```
+  ```powershell
   Import-Csv password.csv|%{Set-MsolUserPassword -userPrincipalName $_.upn -NewPassword $_.newpassword -ForceChangePassword $false}
   
   ```
 
 ### Copy all Office 365 accounts with a specific proxy address into a CSV file
 
-```
+```powershell
 ##########################################################################
 # Script: showproxies.ps1
 # Copies all accounts in Office 365 that contain/don't contain a specific 
@@ -251,7 +251,7 @@ Invoke-Item addresses.csv
 
 ### Bulk Create Room Mailboxes in Office 365
 
-```
+```powershell
 ################################################################################
 #  Script: create-rooms.ps1
 #  Description:*** RUN THIS SCRIPT FROM A WINDOWS POWERSHELL SESSION ***
@@ -296,7 +296,7 @@ New-mailbox -Name $_.RoomName -room -primarysmtpaddress $_.RoomSMTPAddress -reso
 
 ### Bulk remove secondary email address from mailboxes
 
-```
+```powershell
 ##########################################################################
 #      Script:  remove-proxy.ps1
 #Description:*** RUN THIS SCRIPT FROM A WINDOWS POWERSHELL SESSION ***


### PR DESCRIPTION
PowerShell identifier added to code blocks in order to enable syntax highlighting for readability.