### PR TITLE
Update back-pressure-exchange-2013-help.md

### DIFF
--- a/Exchange/ExchangeServer2013/back-pressure-exchange-2013-help.md
+++ b/Exchange/ExchangeServer2013/back-pressure-exchange-2013-help.md
@@ -366,15 +366,15 @@ All configuration options for back pressure are available in the %ExchangeInstal
 </tr>
 <tr class="even">
 <td><p><em>VersionBucketsHighThreshold</em></p></td>
-<td><p>200</p></td>
+<td><p>2500</p></td>
 </tr>
 <tr class="odd">
 <td><p><em>VersionBucketsMediumThreshold</em></p></td>
-<td><p>120</p></td>
+<td><p>2000</p></td>
 </tr>
 <tr class="even">
 <td><p><em>VersionBucketsNormalThreshold</em></p></td>
-<td><p>80</p></td>
+<td><p>1750</p></td>
 </tr>
 <tr class="odd">
 <td><p><em>VersionBucketsHistoryDepth</em></p></td>


### PR DESCRIPTION
Current values for VersionBucket thresholds for High, Med, Low are incorrect. 200, 120, 80 should be 2500, 2000, 1750 respectively. Change verified in source code and approved by Sr. SPM Scott Landry via CI 90745.