### PR TITLE
Updated PowerShell example to search full AD forest

### DIFF
--- a/Exchange/ExchangeServer/architecture/mailbox-servers/recreate-arbitration-mailboxes.md
+++ b/Exchange/ExchangeServer/architecture/mailbox-servers/recreate-arbitration-mailboxes.md
@@ -3,7 +3,7 @@ title: "Recreate missing arbitration mailboxes"
 ms.author: dmaguire
 author: msdmaguire
 manager: serdars
-ms.date: 8/21/2018
+ms.date: 
 ms.audience: ITPro
 ms.topic: article
 ms.prod: exchange-server-it-pro
@@ -176,12 +176,10 @@ To re-create the arbitration mailbox SystemMailbox{bb558c35-97f1-4cb9-8ff7-d5374
 
 ## How do you know this worked?
 
-To verify that you've successfully re-created the arbitration mailbox, use the **Get-Mailbox** cmdlet with the _Arbitration_ switch to retrieve system mailboxes. But first set the search scope to search the entire Active Directory forest. 
-  
-```
-Set-ADServerSettings -ViewEntireForest:$true
+To verify that you've successfully re-created the arbitration mailbox, set the search scope to search the entire Active Directory forest, an then use the **Get-Mailbox** cmdlet with the _Arbitration_ switch to retrieve system mailboxes.
 
-Get-Mailbox -Arbitration | Format-Table Name, DisplayName
+```
+Set-ADServerSettings -ViewEntireForest $true; Get-Mailbox -Arbitration | Format-Table Name,DisplayName
 ```
 
 View the results of the command to verify that appropriate system mailbox, either by Name or Display Name from the above table, has been re-created.

--- a/Exchange/ExchangeServer/architecture/mailbox-servers/recreate-arbitration-mailboxes.md
+++ b/Exchange/ExchangeServer/architecture/mailbox-servers/recreate-arbitration-mailboxes.md
@@ -176,9 +176,11 @@ To re-create the arbitration mailbox SystemMailbox{bb558c35-97f1-4cb9-8ff7-d5374
 
 ## How do you know this worked?
 
-To verify that you've successfully re-created the arbitration mailbox, use the **Get-Mailbox** cmdlet with the _Arbitration_ switch to retrieve system mailboxes.
+To verify that you've successfully re-created the arbitration mailbox, use the **Get-Mailbox** cmdlet with the _Arbitration_ switch to retrieve system mailboxes. But first set the search scope to search the entire Active Directory forest. 
   
 ```
+Set-ADServerSettings -ViewEntireForest:$true
+
 Get-Mailbox -Arbitration | Format-Table Name, DisplayName
 ```
 


### PR DESCRIPTION
Updated the example to fetch arbitration mailboxes after recreation to search the AD forest and not the local domain only.