### PR TITLE
Changed .NET prerequisites for Exchange 2013 CU21

### DIFF
--- a/Exchange/ExchangeServer2013/exchange-2013-prerequisites-exchange-2013-help.md
+++ b/Exchange/ExchangeServer2013/exchange-2013-prerequisites-exchange-2013-help.md
@@ -119,11 +119,11 @@ Do the following to install the required Windows roles and features:
 
 After you've installed the operating system roles and features, install the following software in the order shown:
 
-1.  [.NET Framework 4.6.2](https://go.microsoft.com/fwlink/p/?linkid=808659)
+1.  [.NET Framework 4.7.1](https://www.microsoft.com/download/details.aspx?id=56116)
     
 
     > [!IMPORTANT]
-    > Exchange 2013 CU16 and later <STRONG>require</STRONG> .NET Framework 4.6.2. Upgrade your servers to .NET Framework 4.6.2 before you install Exchange 2013 CU16 or you'll receive an error. If .NET Framework 4.5.2 is installed on your Exchange servers, upgrade your servers to Exchange 2013 CU15 before installing .NET Framework 4.6.2.
+    > Exchange 2013 CU21 <STRONG>require</STRONG> .NET Framework 4.7.1. Upgrade your servers to .NET Framework 4.7.1 before you install Exchange 2013 CU21 or you'll receive an error. If .NET Framework 4.6.2 is installed on your Exchange servers, upgrade your servers to Exchange 2013 CU20 before installing .NET Framework 4.7.1.
 
 
 
@@ -147,11 +147,11 @@ Do the following to install the required Windows roles and features:
 
 Install the version of Microsoft .NET Framework that corresponds to the version of Exchange 2013 you're installing:
 
-1.  [.NET Framework 4.6.2](https://go.microsoft.com/fwlink/p/?linkid=808659)
+1.  [.NET Framework 4.7.1](https://www.microsoft.com/download/details.aspx?id=56116)
     
 
     > [!IMPORTANT]
-    > Exchange 2013 CU16 and later <STRONG>require</STRONG> .NET Framework 4.6.2. Upgrade your servers to .NET Framework 4.6.2 before you install Exchange 2013 CU16 or you'll receive an error. If .NET Framework 4.5.2 is installed on your Exchange servers, upgrade your servers to Exchange 2013 CU15 before installing .NET Framework 4.6.2.
+    > Exchange 2013 CU21 <STRONG>require</STRONG> .NET Framework 4.7.1. Upgrade your servers to .NET Framework 4.7.1 before you install Exchange 2013 CU21 or you'll receive an error. If .NET Framework 4.6.2 is installed on your Exchange servers, upgrade your servers to Exchange 2013 CU20 before installing .NET Framework 4.7.1.
 
 
 
@@ -189,11 +189,11 @@ Do the following to install the required Windows roles and features:
     
 After you've installed the operating system roles and features, install the following software in the order shown:
 
-1.  [.NET Framework 4.6.2](https://go.microsoft.com/fwlink/p/?linkid=808659)
+1.  [.NET Framework 4.7.1](https://www.microsoft.com/download/details.aspx?id=56116)
     
 
     > [!IMPORTANT]
-    > Exchange 2013 CU16 and later <STRONG>require</STRONG> .NET Framework 4.6.2. Upgrade your servers to .NET Framework 4.6.2 before you install Exchange 2013 CU16 or you'll receive an error. If .NET Framework 4.5.2 is installed on your Exchange servers, upgrade your servers to Exchange 2013 CU15 before installing .NET Framework 4.6.2.
+    > Exchange 2013 CU21 <STRONG>require</STRONG> .NET Framework 4.7.1. Upgrade your servers to .NET Framework 4.7.1 before you install Exchange 2013 CU21 or you'll receive an error. If .NET Framework 4.6.2 is installed on your Exchange servers, upgrade your servers to Exchange 2013 CU20 before installing .NET Framework 4.7.1.
 
 
 
@@ -235,11 +235,11 @@ Do the following to install the required Windows roles and features:
 
 After you've installed the operating system roles and features, install the following software in the order shown:
 
-1.  [.NET Framework 4.6.2](https://go.microsoft.com/fwlink/p/?linkid=808659)
+1.  [.NET Framework 4.7.1](https://www.microsoft.com/download/details.aspx?id=56116)
     
 
     > [!IMPORTANT]
-    > Exchange 2013 CU16 and later <STRONG>require</STRONG> .NET Framework 4.6.2. Upgrade your servers to .NET Framework 4.6.2 before you install Exchange 2013 CU16 or you'll receive an error. If .NET Framework 4.5.2 is installed on your Exchange servers, upgrade your servers to Exchange 2013 CU15 before installing .NET Framework 4.6.2.
+    > Exchange 2013 CU21 <STRONG>require</STRONG> .NET Framework 4.7.1. Upgrade your servers to .NET Framework 4.7.1 before you install Exchange 2013 CU21 or you'll receive an error. If .NET Framework 4.6.2 is installed on your Exchange servers, upgrade your servers to Exchange 2013 CU20 before installing .NET Framework 4.7.1.
 
 
 
@@ -261,7 +261,7 @@ Follow the instructions in this section to install the prerequisites on domain-j
 
 After you've installed the operating system features, install the following software in the order shown:
 
-1.  [.NET Framework 4.6.2](https://go.microsoft.com/fwlink/p/?linkid=808659)
+1.  [.NET Framework 4.7.1](https://www.microsoft.com/download/details.aspx?id=56116)
 
 2.  [Windows Management Framework 4.0](https://go.microsoft.com/fwlink/p/?linkid=390234)
 
@@ -269,5 +269,5 @@ After you've installed the operating system features, install the following soft
 
 ## Windows 8 and Windows 8.1 prerequisites (admin tools only)
 
-[.NET Framework 4.6.2](https://go.microsoft.com/fwlink/p/?linkid=808659)
+[.NET Framework 4.7.1](https://www.microsoft.com/download/details.aspx?id=56116)
 

--- a/Exchange/ExchangeServer2013/exchange-2013-prerequisites-exchange-2013-help.md
+++ b/Exchange/ExchangeServer2013/exchange-2013-prerequisites-exchange-2013-help.md
@@ -131,6 +131,8 @@ After you've installed the operating system roles and features, install the foll
 
 3.  [Microsoft Unified Communications Managed API 4.0, Core Runtime 64-bit](https://go.microsoft.com/fwlink/p/?linkid=258269)
 
+4.  [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
+
 ## Edge Transport server role
 
 Follow the instructions in this section to install the prerequisites on Windows Server 2012 R2 or Windows Server 2012 computers where you want to install the Edge Transport server role on a computer.


### PR DESCRIPTION
Starting with CU21, .NET 4.7.1 is required for installing Exchange 2013. Starting with CU20 .NET 4.7.1 is supported. 
- .NET Version changed
- .NET download link changed
- Changed important notice about .NET (removed CUx and LATER, because there is no planed CU after CU21)
- Added upgrade recommended path from .NET 4.6.2 to .NET 4.7.1