### PR TITLE
Update SMTP Receive wrong information

### DIFF
--- a/Exchange/ExchangeServer2013/mail-flow-exchange-2013-help.md
+++ b/Exchange/ExchangeServer2013/mail-flow-exchange-2013-help.md
@@ -87,7 +87,7 @@ Every message that's sent or received in an Exchange 2013 organization must be c
 
 The Transport service on a Mailbox server consists of the following components and processes:
 
-  - **SMTP Receive**   When messages are received by the Transport service, message content inspection is performed, transport rules are applied, and anti-spam and anti-malware inspection is performed if they are enabled. The SMTP session has a series of events that work together in a specific order to validate the contents of a message before it's accepted. After a message has passed completely through SMTP Receive and isn't rejected by receive events, or by an anti-spam and anti-malware agent, it's put in the Submission queue.
+  - **SMTP Receive**   When messages are received by the Transport service, message content inspection is performed and antispam inspection is performed if is enabled. The SMTP session has a series of events that work together in a specific order to validate the contents of a message before it's accepted. After a message has passed completely through SMTP Receive and isn't rejected by receive events, or by an antispam agent, it's put in the Submission queue.
 
   - **Submission**   Submission is the process of putting messages into the Submission queue. The categorizer picks up one message at a time for categorization. Submission happens in three ways:
     


### PR DESCRIPTION
Hi,
According with the Exchange 2013SP1 Architecture Poster (https://www.microsoft.com/en-us/download/details.aspx?id=42542) the Transport Rules are applied on Categorizer at “Recipient Resolution” stage. As far as I know in the OnResolved extensibility point.
Regarding the Malware agent, the Architecture Poster shows that it is processing on Categorizer at “Agent Processing Submitted Messages” stage, in the OnSubmitted extensibility point.
In the Exchange 2016 and 2019 documentation this information is already merged (https://github.com/MicrosoftDocs/OfficeDocs-Exchange/pull/284)
Regards,
Denis Signorelli