### PR TITLE
Update prerequisites.md

### DIFF
--- a/Exchange/ExchangeServer/plan-and-deploy/prerequisites.md
+++ b/Exchange/ExchangeServer/plan-and-deploy/prerequisites.md
@@ -119,7 +119,7 @@ When you use one of these options, you don't need to restart the computer after 
 
    - **Server Core**:
 
-  ## Remove AS-HTTP-Activation it's not valid Component on  Windows Server 2016    ```
+      ```
       Install-WindowsFeature Server-Media-Foundation, NET-Framework-45-Features, RPC-over-HTTP-proxy, RSAT-Clustering, RSAT-Clustering-CmdInterface, RSAT-Clustering-Mgmt, RSAT-Clustering-PowerShell, WAS-Process-Model, Web-Asp-Net45, Web-Basic-Auth, Web-Client-Auth, Web-Digest-Auth, Web-Dir-Browsing, Web-Dyn-Compression, Web-Http-Errors, Web-Http-Logging, Web-Http-Redirect, Web-Http-Tracing, Web-ISAPI-Ext, Web-ISAPI-Filter, Web-Metabase, Web-Mgmt-Service, Web-Net-Ext45, Web-Request-Monitor, Web-Server, Web-Stat-Compression, Web-Static-Content, Web-Windows-Auth, Web-WMI, Windows-Identity-Foundation, RSAT-ADDS
       ```
     

--- a/Exchange/ExchangeServer/plan-and-deploy/prerequisites.md
+++ b/Exchange/ExchangeServer/plan-and-deploy/prerequisites.md
@@ -119,8 +119,8 @@ When you use one of these options, you don't need to restart the computer after 
 
    - **Server Core**:
 
-      ```
-      Install-WindowsFeature AS-HTTP-Activation, Server-Media-Foundation, NET-Framework-45-Features, RPC-over-HTTP-proxy, RSAT-Clustering, RSAT-Clustering-CmdInterface, RSAT-Clustering-Mgmt, RSAT-Clustering-PowerShell, WAS-Process-Model, Web-Asp-Net45, Web-Basic-Auth, Web-Client-Auth, Web-Digest-Auth, Web-Dir-Browsing, Web-Dyn-Compression, Web-Http-Errors, Web-Http-Logging, Web-Http-Redirect, Web-Http-Tracing, Web-ISAPI-Ext, Web-ISAPI-Filter, Web-Metabase, Web-Mgmt-Service, Web-Net-Ext45, Web-Request-Monitor, Web-Server, Web-Stat-Compression, Web-Static-Content, Web-Windows-Auth, Web-WMI, Windows-Identity-Foundation, RSAT-ADDS
+  ## Remove AS-HTTP-Activation it's not valid Component on  Windows Server 2016    ```
+      Install-WindowsFeature Server-Media-Foundation, NET-Framework-45-Features, RPC-over-HTTP-proxy, RSAT-Clustering, RSAT-Clustering-CmdInterface, RSAT-Clustering-Mgmt, RSAT-Clustering-PowerShell, WAS-Process-Model, Web-Asp-Net45, Web-Basic-Auth, Web-Client-Auth, Web-Digest-Auth, Web-Dir-Browsing, Web-Dyn-Compression, Web-Http-Errors, Web-Http-Logging, Web-Http-Redirect, Web-Http-Tracing, Web-ISAPI-Ext, Web-ISAPI-Filter, Web-Metabase, Web-Mgmt-Service, Web-Net-Ext45, Web-Request-Monitor, Web-Server, Web-Stat-Compression, Web-Static-Content, Web-Windows-Auth, Web-WMI, Windows-Identity-Foundation, RSAT-ADDS
       ```
     
 ### Exchange 2019 Edge Transport servers on Windows Server 2019


### PR DESCRIPTION
Remove AS-HTTP-Activation from to Install Windows prerequisites Component  Powershell Command  in Windows Core Part because AS-HTTP-Activation  it's Not Valid  Windows components in Windows Server Core 2016 

Install-WindowsFeature : ArgumentNotValid: The role, role service, or feature name is not valid: 'AS-HTTP-Activation'.