### PR TITLE
Fixing missing variable in code sample

### DIFF
--- a/Exchange/ExchangeOnline/mailbox-migration/migrate-mailboxes-across-tenants.md
+++ b/Exchange/ExchangeOnline/mailbox-migration/migrate-mailboxes-across-tenants.md
@@ -229,7 +229,7 @@ ForEach ($mbx in $Mailboxes) {
     # Loop through every address assigned to the mailbox  
     Foreach ($address in $mbx.EmailAddresses) {  
        # If it contains XXX,  Record it  
-        if ($address.ToString().ToLower().contains("onmicrosoft.com")) {  
+        if ($address.ToString().ToLower().contains($proxyaddr)) {  
             # This is an email address. Add it to the list  
             $obj = "" | Select-Object Alias,EmailAddress  
             $obj.Alias = $mbx.Alias  


### PR DESCRIPTION
Fixing script to search for proxy addresses missing variable. Variable $proxyaddr that defines proxy address string to search for was defined but never referenced.