### PR TITLE
Update set-up-modern-hybrid-public-folders.md

### DIFF
--- a/Exchange/ExchangeHybrid/hybrid-deployment/set-up-modern-hybrid-public-folders.md
+++ b/Exchange/ExchangeHybrid/hybrid-deployment/set-up-modern-hybrid-public-folders.md
@@ -33,7 +33,7 @@ An Exchange Online/Office 365 user must be represented by a MailUser object in t
 
 1. These instructions assume that you have used the Hybrid Configuration Wizard to configure and synchronize your on-premises and Exchange Online environments and that the DNS records used for most users' AutoDiscover references an on-premises end-point. For more information, see [Hybrid Configuration wizard](../hybrid-configuration-wizard.md).
     
-2. These instructions assume that Outlook Anywhere is enabled and functional on the on-premises Exchange server(s). For information on how to enable Outlook Anywhere, see [Outlook Anywhere](http://technet.microsoft.com/library/9026d461-ec6a-4ef5-ba9d-de33030858f3.aspx).
+2. The public folders in this configuration cannot be accessed using OWA.
     
 3. Implementing public folder coexistence for a hybrid deployment of Exchange with Office 365 may require you to fix conflicts during the import procedure. Conflicts can happen due to non-routable email address assigned to mail enabled public folders, conflicts with other users and groups in Office 365, and other attributes. 
     
@@ -41,7 +41,6 @@ An Exchange Online/Office 365 user must be represented by a MailUser object in t
     
 1. To download the November 2012 Outlook update for Outlook 2010, see [Update for Microsoft Outlook 2010 (KB2687623) 32-Bit Edition](https://www.microsoft.com/en-us/download/details.aspx?id=35702).
     
-2. To download the November 2012 Outlook Update for Outlook 2007, see [Update for Microsoft Office Outlook 2007 (KB2687404)](https://www.microsoft.com/en-us/download/details.aspx?id=35718).
     
 5. Outlook 2011 for Mac and Outlook for Mac for Office 365 are not supported for cross-premises public folders. Users must be in the same location as the public folders to access them with Outlook 2011 for Mac or Outlook for Mac for Office 365. In addition, users whose mailboxes are in Exchange Online won't be able to access on-premises public folders using Outlook Web App.
     


### PR DESCRIPTION
Removed line that mentions make sure outlook anywhere must be enabled, since its always enabled on Exchange 2013+ servers
Added line to mention public folders in this configuration cannot be accessed using OWA
Removed the line for Outlook 2007, since it's out of support