### PR TITLE
Visual C++ 2012 runtime req. added to Edge server

### DIFF
--- a/Exchange/ExchangeServer2013/exchange-2013-prerequisites-exchange-2013-help.md
+++ b/Exchange/ExchangeServer2013/exchange-2013-prerequisites-exchange-2013-help.md
@@ -131,7 +131,9 @@ After you've installed the operating system roles and features, install the foll
 
 3.  [Microsoft Unified Communications Managed API 4.0, Core Runtime 64-bit](https://go.microsoft.com/fwlink/p/?linkid=258269)
 
-4.  [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
+4.  [Visual C++ Redistributable Packages for Visual Studio 2012](https://www.microsoft.com/en-us/download/details.aspx?id=30679)
+
+5.  [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
 
 ## Edge Transport server role
 
@@ -205,13 +207,15 @@ After you've installed the operating system roles and features, install the foll
 
 3.  [Microsoft Unified Communications Managed API 4.0, Core Runtime 64-bit](https://go.microsoft.com/fwlink/p/?linkid=258269)
 
-4.  [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
+4.  [Visual C++ Redistributable Packages for Visual Studio 2010](https://www.microsoft.com/en-us/download/details.aspx?id=30679)
 
-5.  [Microsoft Knowledge Base article KB974405 (Windows Identity Foundation)](http://go.microsoft.com/fwlink/?linkid=3052&kbid=974405)
+5.  [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
 
-6.  [Knowledge Base article KB2619234 (Enable the Association Cookie/GUID that is used by RPC over HTTP to also be used at the RPC layer in Windows 7 and in Windows Server 2008 R2)](http://go.microsoft.com/fwlink/?linkid=3052&kbid=2619234)
+6.  [Microsoft Knowledge Base article KB974405 (Windows Identity Foundation)](http://go.microsoft.com/fwlink/?linkid=3052&kbid=974405)
 
-7.  [Knowledge Base article KB2533623 (Insecure library loading could allow remote code execution)](http://go.microsoft.com/fwlink/?linkid=3052&kbid=2533623)
+7.  [Knowledge Base article KB2619234 (Enable the Association Cookie/GUID that is used by RPC over HTTP to also be used at the RPC layer in Windows 7 and in Windows Server 2008 R2)](http://go.microsoft.com/fwlink/?linkid=3052&kbid=2619234)
+
+8.  [Knowledge Base article KB2533623 (Insecure library loading could allow remote code execution)](http://go.microsoft.com/fwlink/?linkid=3052&kbid=2533623)
     
 
     > [!NOTE]
@@ -253,7 +257,7 @@ After you've installed the operating system roles and features, install the foll
 
 3.  [Microsoft Unified Communications Managed API 4.0, Core Runtime 64-bit](https://go.microsoft.com/fwlink/p/?linkid=258269)
 
-4.  [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
+4.  [Visual C++ Redistributable Packages for Visual Studio 2012](https://www.microsoft.com/en-us/download/details.aspx?id=30679)
 
 ## Windows 7 prerequisites (admin tools only)
 

--- a/Exchange/ExchangeServer2013/exchange-2013-prerequisites-exchange-2013-help.md
+++ b/Exchange/ExchangeServer2013/exchange-2013-prerequisites-exchange-2013-help.md
@@ -207,7 +207,7 @@ After you've installed the operating system roles and features, install the foll
 
 3.  [Microsoft Unified Communications Managed API 4.0, Core Runtime 64-bit](https://go.microsoft.com/fwlink/p/?linkid=258269)
 
-4.  [Visual C++ Redistributable Packages for Visual Studio 2010](https://www.microsoft.com/en-us/download/details.aspx?id=30679)
+4.  [Visual C++ Redistributable Packages for Visual Studio 2012](https://www.microsoft.com/en-us/download/details.aspx?id=30679)
 
 5.  [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
 

--- a/Exchange/ExchangeServer2013/exchange-2013-prerequisites-exchange-2013-help.md
+++ b/Exchange/ExchangeServer2013/exchange-2013-prerequisites-exchange-2013-help.md
@@ -159,6 +159,8 @@ Install the version of Microsoft .NET Framework that corresponds to the version 
 
 2.  [Windows Management Framework 4.0](https://go.microsoft.com/fwlink/p/?linkid=390234) (included with Windows Server 2012 R2)
 
+3.  [Visual C++ Redistributable for Visual Studio 2012](https://www.microsoft.com/download/details.aspx?id=30679)
+
 ## Windows Server 2008 R2 SP1 prerequisites
 
 The prerequisites that are needed to install Exchange 2013 on a Windows Server 2008 R2 SP1 computer depends on which Exchange roles you want to install. Read the section below that matches the roles you want to install.


### PR DESCRIPTION
As described here: https://blogs.technet.microsoft.com/exchange/2019/02/12/released-february-2019-quarterly-exchange-updates/

"Important: To avoid a setup failure, it is necessary to install the Visual C++ 2012 runtime before installing Cumulative Update 22 or Cumulative Update 12 on Edge role if not already present."