### PR TITLE
Complete-MigrationBatch Mismatch

### DIFF
--- a/Exchange/ExchangeServer/collaboration/public-folders/batch-migration-from-previous-versions.md
+++ b/Exchange/ExchangeServer/collaboration/public-folders/batch-migration-from-previous-versions.md
@@ -357,7 +357,7 @@ Set-OrganizationConfig -PublicFoldersEnabled Remote
 Once that is done, you can complete the public folder migration by running the following command:
 
 ```
-Complete-MigrationBatch PublicFolderMigration
+Complete-MigrationBatch PFMigration
 
 ```
 


### PR DESCRIPTION
Migration batch name should be "PFMigration" to match other examples in the documentation. If people are copying and pasting commands, "Complete-MigrationBatch" will result in an error because the batch created earlier is named "PFMigration" and not "PublicFolderMigration".