### PR TITLE
Removed duplicate links in intro

### DIFF
--- a/Exchange/ExchangeOnline/mail-flow-best-practices/non-delivery-reports-in-exchange-online/fix-error-code-550-5-1-10-in-exchange-online.md
+++ b/Exchange/ExchangeOnline/mail-flow-best-practices/non-delivery-reports-in-exchange-online/fix-error-code-550-5-1-10-in-exchange-online.md
@@ -20,13 +20,9 @@ description: "Learn how to fix email issues for error code 550 5.1.10 in Exchang
 
 Problems sending and receiving email messages can be frustrating. If you get a non-delivery report (NDR), also called a bounce message, for error code 550 5.1.10, this article can help you fix the problem and get your message sent.
 
-[I got this bounce message. How do I fix it?](#i-got-this-bounce-message-how-do-i-fix-it)
+![Email user icon](../../media/31425afd-41a9-435e-aa85-6886277c369b.png) [I got this bounce message. How do I fix it?](#i-got-this-bounce-message-how-do-i-fix-it)
 
-[I'm an email admin. How can I fix this?](#im-an-email-admin-how-can-i-fix-this)
-
-|||||
-|:-----|:-----|:-----|:-----|
-|[![Email user icon](../../media/31425afd-41a9-435e-aa85-6886277c369b.png)]|[I got this bounce message. How do I fix it?](#i-got-this-bounce-message-how-do-i-fix-it)|[![Email admin icon](../../media/3d4c569e-b819-4a29-86b1-4b9619cf2acf.png)][I'm an email admin. How can I fix this?](#im-an-email-admin-how-can-i-fix-this)|
+![Email admin icon](../../media/3d4c569e-b819-4a29-86b1-4b9619cf2acf.png) [I'm an email admin. How can I fix this?](#im-an-email-admin-how-can-i-fix-this)
 
 ## Why did I get this bounce message?
 


### PR DESCRIPTION
The admin and end user anchor links in the intro were both duplicated in a table. The table had formatting issues (extra brackets), so I moved the images to the first occurence of each link and deleted the table, which was not needed.