### PR TITLE
Solving Issue #661

### DIFF
--- a/Exchange/ExchangeServer/plan-and-deploy/system-requirements.md
+++ b/Exchange/ExchangeServer/plan-and-deploy/system-requirements.md
@@ -102,12 +102,8 @@ We don't support installing Office client or Office server software on Exchange 
 We strongly recommend that you use the latest version of the .NET Framework that's supported by the release of Exchange you're installing.
 
 > [!IMPORTANT]
-> **Releases of .NET Framework that aren't listed in the table below aren't supported on any release of Exchange 2019**. This includes minor and patch-level releases of .NET Framework.
+> **Releases of .NET Framework that aren't listed in the table below aren't supported on any release of Exchange 2019**. This includes minor and patch-level releases of .NET Framework. <br/><br/> The complete prerequisite list for Exchange 2019 is available [here](https://docs.microsoft.com/exchange/plan-and-deploy/prerequisites?view=exchserver-2019).
 
-> [!IMPORTANT]
-> The complete prerequisite list for [** exchange 2019 is available here**](https://docs.microsoft.com/exchange/plan-and-deploy/prerequisites?view=exchserver-2019)
-
- 
 |**Exchange version**|**.NET Framework 4.7.2 or later**|
 |:-----|:-----|
 |Exchange 2019|Supported|
@@ -120,11 +116,11 @@ We strongly recommend that you use the latest version of the .NET Framework that
 
 - Outlook 2016
 
-- Outlook 2016 for Mac
-
 - Outlook 2013
 
 - Outlook for Mac for Office 365
+
+- Outlook 2016 for Mac
 
 > [!IMPORTANT]
 > You need KB3140245 to apply registry keys to enable TLS 1.1 & 1.2 support for Windows 7, otherwise Outlook 2013 and 2016 will not work on Windows 7.

--- a/Exchange/ExchangeServer/plan-and-deploy/system-requirements.md
+++ b/Exchange/ExchangeServer/plan-and-deploy/system-requirements.md
@@ -104,7 +104,11 @@ We strongly recommend that you use the latest version of the .NET Framework that
 > [!IMPORTANT]
 > **Releases of .NET Framework that aren't listed in the table below aren't supported on any release of Exchange 2019**. This includes minor and patch-level releases of .NET Framework.
 
-|**Exchange version**|**.NET Framework 4.7.2**|
+> [!IMPORTANT]
+> The complete prerequisite list for [** exchange 2019 is available here**](https://docs.microsoft.com/exchange/plan-and-deploy/prerequisites?view=exchserver-2019)
+
+ 
+|**Exchange version**|**.NET Framework 4.7.2 or later**|
 |:-----|:-----|
 |Exchange 2019|Supported|
 
@@ -230,6 +234,10 @@ We strongly recommend that you use the latest version of .NET Framework that's s
 
 > [!IMPORTANT]
 > **Releases of .NET Framework that aren't listed in the table below are not supported on any release of Exchange 2016**. This includes minor and patch-level releases of .NET Framework.
+
+> [!IMPORTANT]
+> The complete prerequisite list for [** exchange 2016 is available here**](https://docs.microsoft.com/exchange/plan-and-deploy/prerequisites?view=exchserver-2016)
+
 
 |**Exchange version**|**.NET Framework 4.7.2**|**.NET Framework 4.7.1**|**.NET Framework 4.6.2**|
 |:-----|:-----|:-----|:-----|


### PR DESCRIPTION
Implemented Exchange 2019 on WS2019, with .net framework 4.8 
Which makes it 4.7.2 or higher,   .net 4.7.3 doesn't exist.
Solving Issue #661 
https://docs.microsoft.com/en-us/exchange/plan-and-deploy/prerequisites?view=exchserver-2019