### PR TITLE
Reword sections for clarity related to filling out pages in the G Suite Migration Wizard

### DIFF
--- a/Exchange/ExchangeOnline/mailbox-migration/perform-G-Suite-migration.md
+++ b/Exchange/ExchangeOnline/mailbox-migration/perform-G-Suite-migration.md
@@ -172,7 +172,7 @@ The primary email address that you provision for each user should be the same as
 
 5. After selecting the CSV file, click **Open**. Back on the **new migration batch** page, click **Next**.
 
-6. Enter an email address from the G Suite environment. This email address will be used to test connectivity between G Suite and Office 365.
+6. Enter an email address for a user within the G Suite environment. This email address will be used to test connectivity between G Suite and Office 365.
 
 7. Under **Specify the service account credentials using the JSON key file**,click **Choose File**, and then select the JSON file that was downloaded automatically when you created your service account. This file contains the private key for the service account. Click **Open** to select the file, and then, back on the **new migration batch** page, click **Next**.
 
@@ -181,7 +181,7 @@ The primary email address that you provision for each user should be the same as
    > [!NOTE]
    > Click to select **Skip verification** if you don't want to verify the migration endpoint.
 
-8. In the fields under **Move configuration**, name your migration batch and specify the target delivery domain, which is the domain used for routing mail to the Office 365 target organization from the G Suite source organization. Optionally, you can also specify a bad item limit and a large item limit, and you can specify any folders that should be excluded from the migration. When done, click **Next**.  
+8. In the fields under **Move configuration**, name your migration batch and enter the target delivery domain, which is the domain [you created](#create-a-sub-domain-for-mail-routing-to-office-365) for routing mail to the Office 365 target organization from the G Suite source organization. Optionally, you can also specify a bad item limit and a large item limit, and you can specify any folders that should be excluded from the migration. When done, click **Next**.  
 
    ![batch name](../media/gsuite-mig-16-eac-batch.png)
 

--- a/Exchange/ExchangeOnline/mailbox-migration/perform-G-Suite-migration.md
+++ b/Exchange/ExchangeOnline/mailbox-migration/perform-G-Suite-migration.md
@@ -97,7 +97,7 @@ If your project doesn't already have all of the required APIs enabled, you must 
 
    - Google Calendar API
 
-   - Google Contacts API
+   - Contacts API
 
 ## Grant access to the service account for your Google tenant
 


### PR DESCRIPTION
Product team has received some feedback that admins are confused by the instruction to "specify" the Target Delivery Domain, thinking that the option may appear in the dropdown.  The dropdown is only there for Hybrid scenarios.  Changing the wording to "enter" to make it clearer that they will need to type in the value.

Also, some indications show that admins are confused about what the Target Delivery Domain value should be.  Adding a link back to the section containing the instructions for creating the domain that they should use for value.

Finally, I think that "email address for a user within" is more specific than "email address from".