### PR TITLE
.NET support matrix updated

### DIFF
--- a/Exchange/ExchangeServer/plan-and-deploy/supportability-matrix.md
+++ b/Exchange/ExchangeServer/plan-and-deploy/supportability-matrix.md
@@ -201,25 +201,28 @@ The following tables identify the versions of the Microsoft .NET Framework that 
 
 ### Exchange 2019
 
-|**.NET Framework**|**Exchange 2019**|
-|:-----|:-----|
-|.NET Framework 4.7.2|X|
+|**.NET Framework**|**CU2**|**RTM, CU1**|
+|:-----|:-----|:-----|
+|.NET Framework 4.8|X||
+|.NET Framework 4.7.2|X|X|
 
 ### Exchange 2016
 
-|**.NET Framework**|**CU11, CU12**|**CU10**|**CU8, CU9**|**CU5, CU6, CU7**|
-|:-----|:-----|:-----|:-----|:-----|
-|.NET Framework 4.7.2|X||||
-|.NET Framework 4.7.1|X|X|X||
-|.NET Framework 4.6.2|||X|X|
+|**.NET Framework**|**CU13**|**CU11, CU12**|**CU10**|**CU8, CU9**|**CU5, CU6, CU7**|
+|:-----|:-----|:-----|:-----|:-----|:-----|
+|.NET Framework 4.8|X|||||
+|.NET Framework 4.7.2|X|X||||
+|.NET Framework 4.7.1||X|X|X||
+|.NET Framework 4.6.2||||X|X|
 
 ### Exchange 2013
 
-|**.NET Framework**|**CU21 or later**|**CU19, CU20**|**CU16, CU17, CU18**|
-|:-----|:-----|:-----|:-----|
-|.NET Framework 4.7.2|X|||
-|.NET Framework 4.7.1|X|X||
-|.NET Framework 4.6.2||X|X|
+|**.NET Framework**|**CU23**|**CU21, CU22**|**CU19, CU20**|**CU16, CU17, CU18**|
+|:-----|:-----|:-----|:-----|:-----|
+|.NET Framework 4.8|X||||
+|.NET Framework 4.7.2|X|X|||
+|.NET Framework 4.7.1||X|X||
+|.NET Framework 4.6.2|||X|X|
 
 ### Exchange 2010 SP3
 


### PR DESCRIPTION
With E15 CU23, E16 CU13 and E19 CU2 we now support .NET 4.8. We also require .NET 4.7.2 with this update.
https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Released-June-2019-Quarterly-Exchange-Updates/ba-p/698398