### PR TITLE
Update safety-net.md

### DIFF
--- a/Exchange/ExchangeServer/mail-flow/transport-high-availability/safety-net.md
+++ b/Exchange/ExchangeServer/mail-flow/transport-high-availability/safety-net.md
@@ -61,7 +61,7 @@ This table describes the parameters that are used by Safety Net.
 
 In Microsoft Exchange Server 2019 and 2016, the maximum supported database size for the transport Safety Net JET database is 2 TB.
 
-When a Hub-and-spoke topology is used, the transport Safety Net JET database can grow beyond 2 TB. To stay within the supported limit of 2 TB, following these guidelines:
+When a Hub-and-spoke topology is used, the transport Safety Net JET database can grow beyond 2 TB. To stay within the supported limit of 2 TB, follow these guidelines:
 
 -	Hub servers that are used for message relay can’t be configured to deliver messages to mailboxes.
 


### PR DESCRIPTION
Follow-up to pr 1143 per Content Idea Request 101414: 

Original text corrected under "Safety Net maximum supported sizes": 

Changed "To stay within the supported limit of 2 TB, following these guidelines" to "To stay within the supported limit of 2 TB, follow these guidelines."