### PR TITLE
Remove note about hiding a mailbox

### DIFF
--- a/Exchange/ExchangeOnline/address-books/address-lists/manage-address-lists.md
+++ b/Exchange/ExchangeOnline/address-books/address-lists/manage-address-lists.md
@@ -240,8 +240,6 @@ Get-AddressList
 
 Hiding a recipient from address lists doesn't prevent the recipient from receiving email messages; it prevents users from finding the recipient in address lists. The recipient is hidden from **all** address lists and GALs (effectively, they're exceptions to the recipient filters in all address lists). If you want to selectively include the recipient in some address lists but not others, you need to adjust the recipient filters in the address lists to include or exclude the recipient.
 
-Hiding a mailbox from address lists also prevents Outlook from finding the mailbox in GAL when you create a new profile, or add an additional mailbox to an existing profile. To add the hidden mailbox in Outlook, you can temporarily make the mailbox visible in address lists, configure Outlook, and then hide the mailbox from address lists again.
-
 ### Use the EAC to hide recipients from address lists
 
 To open the EAC, see [Exchange admin center in Exchange Online](../../exchange-admin-center.md).


### PR DESCRIPTION
Currently, this part doesn't correct. 
Outlook profile can be created even if the account is hidden from address list.