### PR TITLE
added closing double quotes in Set-Mailbox Cmdlet

### DIFF
--- a/Exchange/ExchangeServer/antispam-and-antimalware/antispam-protection/configure-antispam-settings.md
+++ b/Exchange/ExchangeServer/antispam-and-antimalware/antispam-protection/configure-antispam-settings.md
@@ -363,7 +363,7 @@ Set-Mailbox <MailboxIdentity> -AntispamBypassEnabled <$true | $false>
 This example exempts messages that are sent to the mailbox named Customer Support from Exchange antispam filtering.
 
 ```PowerShell
-Set-Mailbox "Customer Support -AntispamBypassEnabled $true
+Set-Mailbox "Customer Support" -AntispamBypassEnabled $true
 ```
 
 ### How do you know this worked?


### PR DESCRIPTION
In section "Use the Exchange Management Shell to configure a mailbox to bypass Exchange antispam filtering" the closing double quotes were missing in PS cmdlet:
Set-Mailbox "Customer Support" -AntispamBypassEnabled $true