### PR TITLE
Update hybrid-deployment-prerequisites.md

### DIFF
--- a/Exchange/ExchangeHybrid/hybrid-deployment-prerequisites.md
+++ b/Exchange/ExchangeHybrid/hybrid-deployment-prerequisites.md
@@ -72,7 +72,7 @@ The following prerequisites are required for configuring a hybrid deployment:
 
   The Internet Information Services (IIS) instance on the Exchange servers that are configured in the hybrid deployment require a valid digital certificate purchased from a trusted CA.
   
-  The EWS external URL and the Autodiscover endpoint that you specified in your public DNS must be listed in Subject Alternative Name (SAN) of the certificate. The certificate that you install on the Exchange servers for mail flow in the hybrid deployment must all use the same certificate (that is, they are issued by the same CA and have the same subject).
+  The EWS external URL and the Autodiscover endpoint that you specified in your public DNS must be listed in Subject Alternative Name (SAN) of the certificate. The certificates that you install on the Exchange servers for mail flow in the hybrid deployment must all use the same certificate authority (that is, they are issued by the same CA and have the same subject).
 
   Learn more at [Certificate requirements for hybrid deployments](certificate-requirements.md).
 


### PR DESCRIPTION
Sentence hard to understand as you might have forgotten and "s" on  "The certificates" and I think you wanted to write that the certificates deployed on Exchange servers on an Hybrid deployment must all use the same "certificate authority" (or "certification authority") ...