### PR TITLE
Added Outlook 2019 and Office 365 ProPlus client

### DIFF
--- a/Exchange/ExchangeServer2013/exchange-2013-system-requirements-exchange-2013-help.md
+++ b/Exchange/ExchangeServer2013/exchange-2013-system-requirements-exchange-2013-help.md
@@ -348,6 +348,9 @@ We strongly recommend that you use the latest version of .NET Framework that's s
 ## Supported clients
 
 Exchange 2013 supports the following versions of Outlook and Entourage for Mac:
+- Office 365 ProPlus
+
+- Outlook 2019
 
 - Outlook 2016
 


### PR DESCRIPTION
As documented here: https://docs.microsoft.com/en-us/exchange/plan-and-deploy/supportability-matrix?view=exchserver-2016#clients we support Outlook 2019 and Office 365 ProPlus Outlook client to connect to Exchange 2013.