### PR TITLE
Multi valued list needs to be unquoted

### DIFF
--- a/Exchange/ExchangeServer/architecture/client-access/create-ca-certificate-requests.md
+++ b/Exchange/ExchangeServer/architecture/client-access/create-ca-certificate-requests.md
@@ -161,8 +161,10 @@ This example creates a certificate request on the local Exchange server for a SA
 
 - **FriendlyName**: Contoso.com SAN Cert
 
+- **DomainName**: Unquoted comma-separated list of domains
+
 ```PowerShell
-New-ExchangeCertificate -GenerateRequest -RequestFile "\\FileServer01\Data\Contoso SAN Cert.req" -FriendlyName "Contoso.com SAN Cert" -SubjectName "C=US,CN=mail.contoso.com" -DomainName "autodiscover.contoso.com,legacy.contoso.com,mail.contoso.net,autodiscover.contoso.net,legacy.contoso.net"
+New-ExchangeCertificate -GenerateRequest -RequestFile "\\FileServer01\Data\Contoso SAN Cert.req" -FriendlyName "Contoso.com SAN Cert" -SubjectName "C=US,CN=mail.contoso.com" -DomainName autodiscover.contoso.com,legacy.contoso.com,mail.contoso.net,autodiscover.contoso.net,legacy.contoso.net
 ```
 
 This example creates a request for a single subject certificate with the following properties:


### PR DESCRIPTION
If the DomainName list is quoted one will get the error message that follows.
The message indicates it is seeing the entire list as one string, and trying to parse it as one domain name, which results in the failure. Unquoted is the proper way for the string to be parsed into a MultiValuedProperty.
This was tested and confirmed.

----- error message below -----
Cannot process argument transformation on parameter 'DomainName'. Cannot convert value "autodiscover.contoso.com,legacy.contoso.com,mail.contoso.net,autodiscover.contoso.net,legacy.contoso.net" to type
"Microsoft.Exchange.Data.MultiValuedProperty`1[Microsoft.Exchange.Data.SmtpDomainWithSubdomains]". Error: "Failed to
convert autodiscover.contoso.com,legacy.contoso.com,mail.contoso.net,autodiscover.contoso.net,legacy.contoso.net from
System.String to Microsoft.Exchange.Data.SmtpDomainWithSubdomains. Error: Error while converting string
'autodiscover.contoso.com,legacy.contoso.com,mail.contoso.net,autodiscover.contoso.net,legacy.contoso.net' to result type
Microsoft.Exchange.Data.SmtpDomainWithSubdomains:
"autodiscover.contoso.com,legacy.contoso.com,mail.contoso.net,autodiscover.contoso.net,legacy.contoso.net" isn't a valid
SMTP domain."