### PR TITLE
Proxy outbound through Front End does not make any sense for exchange…

### DIFF
--- a/Exchange/ExchangeServer/mail-flow/connectors/proxy-outbound-mail.md
+++ b/Exchange/ExchangeServer/mail-flow/connectors/proxy-outbound-mail.md
@@ -28,7 +28,7 @@ However, you can configure a Send connector to relay or *proxy* outbound mail th
 
 By default, all inbound mail enters your Exchange organization through the Front End Transport service, and the Front End Transport service proxies inbound mail to the Transport service. For more information, see [Mail flow and the transport pipeline](../../mail-flow/mail-flow.md).
 
-When you configure a Send connector to proxy outbound mail through the Front End Transport service, the Receive connector named "Outbound Proxy Frontend _\<Mailbox server name\>_" in the Front End Transport service listens for these outbound messages from the Transport service, and then the Front End Transport service sends the messages to the Internet. This configuration can consolidate and simplify mail flow by having inbound and outbound mail enter and leave your organization from the same place.
+When you configure a Send connector to proxy outbound mail through the Front End Transport service, the Receive connector named "Outbound Proxy Frontend _\<Mailbox server name\>_" in the Front End Transport service listens for these outbound messages from the Transport service, and then the Front End Transport service sends the messages to the Internet.
 
 ## What do you need to know before you begin?
 

--- a/Exchange/ExchangeServer/mail-flow/connectors/proxy-outbound-mail.md
+++ b/Exchange/ExchangeServer/mail-flow/connectors/proxy-outbound-mail.md
@@ -28,7 +28,7 @@ However, you can configure a Send connector to relay or *proxy* outbound mail th
 
 By default, all inbound mail enters your Exchange organization through the Front End Transport service, and the Front End Transport service proxies inbound mail to the Transport service. For more information, see [Mail flow and the transport pipeline](../../mail-flow/mail-flow.md).
 
-When you configure a Send connector to proxy outbound mail through the Front End Transport service, the Receive connector named "Outbound Proxy Frontend _\<Mailbox server name\>_" in the Front End Transport service listens for these outbound messages from the Transport service, and then the Front End Transport service sends the messages to the Internet.
+When you configure a Send connector to proxy outbound mail through the Front End Transport service, the Receive connector named "Outbound Proxy Frontend _\<Mailbox server name\>_" in the Front End Transport service listens for these outbound messages from the Transport service, and then the Front End Transport service sends the messages to the internet.
 
 ## What do you need to know before you begin?
 


### PR DESCRIPTION
… 2016 or 2019

The Article says the following - 

When you configure a Send connector to proxy outbound mail through the Front End Transport service, the Receive connector named "Outbound Proxy Frontend <Mailbox server name>" in the Front End Transport service listens for these outbound messages from the Transport service, and then the Front End Transport service sends the messages to the Internet. This configuration can consolidate and simplify mail flow by having inbound and outbound mail enter and leave your organization from the same place.

However this statement is not application to Exchange 2016 or 2019. For Exchange 2013, as we could install a CAS role only server, we could enable Proxy through frontend and email would go through these CAS only roles and this way we could achieve consolidation and simplification. Ex2016 onwards, we have both roles together, even with proxy through CAS enabled, mail would still go out from the Source Server only.