### PR TITLE
removed support for S/MIME support for Edge/E16

### DIFF
--- a/Exchange/ExchangeServer/plan-and-deploy/supportability-matrix.md
+++ b/Exchange/ExchangeServer/plan-and-deploy/supportability-matrix.md
@@ -156,7 +156,7 @@ The following table identifies the Web browsers supported for the use of S/MIME 
 
 |**Browser**|**Exchange 2019**|**Exchange 2016**|**Exchange 2013 SP1 and later**|**Exchange 2010 SP3**|
 |:-----|:-----:|:-----:|:-----:|:-----:|
-|Microsoft Edge|![check mark](../media/check-mark.png)|![check mark](../media/check-mark.png)|||
+|Microsoft Edge|![check mark](../media/check-mark.png)||||
 |Internet Explorer 11|![check mark](../media/check-mark.png)|![check mark](../media/check-mark.png)|![check mark](../media/check-mark.png)|![check mark](../media/check-mark.png)|
 |Internet Explorer 10|||![check mark](../media/check-mark.png)|![check mark](../media/check-mark.png)|
 |Internet Explorer 9|||![check mark](../media/check-mark.png)|![check mark](../media/check-mark.png)|


### PR DESCRIPTION
removed support for S/MIME support for Edge and Exchange 2016. This is a 2019 only feature, verified with balinger