### PR TITLE
Error in the process for resending the failed Journal message

### DIFF
--- a/Exchange/ExchangeOnline/security-and-compliance/journaling/configure-journaling.md
+++ b/Exchange/ExchangeOnline/security-and-compliance/journaling/configure-journaling.md
@@ -39,4 +39,4 @@ As previously explained, undeliverable journal reports are queued on Microsoft d
 
 ![Select an alternative journaling mailbox to receive NDRs for undeliverable journal reports](../../media/23408455-a7d2-454b-8375-45be81563c36.png)
 
-The original journal report is an attachment in the NDR. When the journaling mailbox for a undelivered journal report becomes available again, you can use the **Resend this message** feature in Outlook on the NDRs in the alternate journaling mailbox to send the unaltered delivery report to the journaling mailbox.
+The original journal report is an attachment in the NDR. When the journaling mailbox for a undelivered journal report becomes available again, you can use the **Send Again** feature in Outlook on the NDRs in the alternate journaling mailbox to send the unaltered delivery report to the journaling mailbox.


### PR DESCRIPTION
To Resend the message from an NDR, the feature is called "Send Again" and not "Resend this message"