### PR TITLE
Fixed Newark autodiscover URL spelling

### DIFF
--- a/Exchange/ExchangeServer/architecture/client-access/autodiscover.md
+++ b/Exchange/ExchangeServer/architecture/client-access/autodiscover.md
@@ -76,7 +76,7 @@ Client applications use the Autodiscover service when the application starts for
 |:-----|:-----|
 |https://longview.contoso.com/autodiscover/autodiscover.xml|SCP results|
 |https://email.contoso.com/autodiscover/autodiscover.xml|SCP results|
-|https://newark.contoso.com/autodiscover/autodiscovfer.xml|SCP results|
+|https://newark.contoso.com/autodiscover/autodiscover.xml|SCP results|
 |https://contoso.com/autodiscover/autodiscover.exc|Derived from email address|
 |https://autodiscover.contoso.com/autodiscover/autodiscover|Derived from email address|
 


### PR DESCRIPTION
Changed https://newark.contoso.com/autodiscover/autodiscovfer.xml to https://newark.contoso.com/autodiscover/autodiscover.xml