### PR TITLE
Fix source side validation script file name

### DIFF
--- a/Exchange/ExchangeServer/collaboration/public-folders/migrate-to-exchange-online.md
+++ b/Exchange/ExchangeServer/collaboration/public-folders/migrate-to-exchange-online.md
@@ -69,7 +69,7 @@ For instructions on migrating Exchange Server 2010 public folders to Exchange On
 
 The scripts and files you're downloading are:
 
-- `ssv.ps1`:  Source Side Validation script scans the public folders at source and reports issues found along with actions required to fix the issues. You'll run this script on the Exchange server on-premises.
+- `SourceSideValidations.ps1`:  Source Side Validation script scans the public folders at source and reports issues found along with actions required to fix the issues. You'll run this script on the Exchange server on-premises.
 
 - `Sync-ModernMailPublicFolders.ps1` This script synchronizes mail-enabled public folder objects between your Exchange on-premises environment and Office 365. You'll run this script on an on-premises Exchange server.
 


### PR DESCRIPTION
The public folder source-side validation script used to be named ssv.ps1, but is now named SourceSideValidations.ps1. This PR updates the name in the docs.