### PR TITLE
Tweaking estimated table a bit for mailbox relos

### DIFF
--- a/Exchange/ExchangeOnline/mailbox-migration/office-365-migration-best-practices.md
+++ b/Exchange/ExchangeOnline/mailbox-migration/office-365-migration-best-practices.md
@@ -89,9 +89,9 @@ To help you plan your migration, the following tables present guidelines about w
    |**Mailbox size (GB)**|**50th percentile duration (days)**|**90th percentile duration (days)**|
    |:-----|:-----|:-----|
    |\< 1|1|7|
-   |1 - 10|1|10|
-   |10 - 50|3|30|
-   |50 - 100|15|45|
+   |1 - 9|1|10|
+   |10 - 49|3|30|
+   |50 - 99|15|45|
    |100 - 200|30|60|
    |\> 200|Not supported|Not supported|
 


### PR DESCRIPTION
We had overlapping figures in the Multi-Geo/GoLocal/Encryption table. For example, one row would say mailboxes 10-50 GB and the next row said mailboxes from 50-100GB. I'm changing it so we do not have overlaps, so the previous example would change the rows to be 10-49GB and 50-99GB.