### PR TITLE
Remove some missing information from message-size-limits.md

### DIFF
--- a/Exchange/ExchangeServer/mail-flow/message-size-limits.md
+++ b/Exchange/ExchangeServer/mail-flow/message-size-limits.md
@@ -156,10 +156,6 @@ The order of precedence for message size limits is the most restrictive limit is
 
 An exception to the order is message size limits on mailboxes and messages size limits in mail flow rules. Exchange checks the maximum message size that's allowed on mailboxes before mail flow rules process messages. For example, your organization's message size limit is 50 MB, you configure a 35 MB limit on a mailbox, and you configure a mail flow rule to find and reject messages larger than 40 MB. If an external sender sends a 45 MB message to the mailbox, the message is rejected before the mail flow rule is able to evaluate the message.
 
-Recipient limits between authenticated senders and recipients (typically, internal message senders and recipients) are exempt from the organizational message size restrictions. Therefore, you can configure specific senders and recipients to exceed the default message size limits for your organization. For example, you can allow specific mailboxes to send and receive larger messages than the rest of the organization by configuring custom send and receive limits for those mailboxes.
-
-However, this exemption applies only to messages sent between authenticated senders and recipients (typically, internal senders and recipients). For messages sent between anonymous senders and recipients (typically, Internet senders or Internet recipients), the organizational limits apply. For example, suppose your organizational message size limit is 10 MB, but you configured the users in your marketing department to send and receive messages up to 50 MB. These users will be able to exchange large messages with each other, but not with Internet senders and recipients (unauthenticated senders and recipients).
-
 ### How recipient limits work together
 
 The recipient limit on a message is enforced in two places:


### PR DESCRIPTION
https://github.com/MicrosoftDocs/OfficeDocs-Exchange/issues/2019

I tested it with Exchange 2016:
- Org limit: 50MB
- Mailbox limit: 200MB
- I couldn't send a 90MB attachment.

But please confirm.