### PR TITLE
Removed note in hybrid-agent.md

### DIFF
--- a/Exchange/ExchangeHybrid/hybrid-deployment/hybrid-agent.md
+++ b/Exchange/ExchangeHybrid/hybrid-deployment/hybrid-agent.md
@@ -106,9 +106,6 @@ Keep the following issues in mind before you install the Hybrid Agent:
 
 You must run the HCW from the computer where you want the agent installed. After the Agent is installed and configured, the HCW will locate a preferred server to connect to and run the standard hybrid configuration steps. You do not have to run the HCW from the Exchange server directly, but as stated previously, the computer where the HCW is run must be able to connect to the Client Access Server on the ports specified in the [Ports and protocols](#port-and-protocol-requirements) section.
 
-> [!NOTE]
-> The Modern Hybrid option will only be presented if you have never run the Hybrid Configuration wizard. If you have successfully established Hybrid in either Minimal or Full in the "classic config" for your tenant, this new option won't be presented to you.
-
 ### Installation Prerequisites
 
 1. Optional: Verify connectivity.


### PR DESCRIPTION
Removed note about the Modern option will only be presented if HCW has never run.

This note was added 2 years ago:
https://github.com/MicrosoftDocs/OfficeDocs-Exchange/commit/8df47d72fa636aa6cbb8dc981494fd071b315ad6

And it was true when the public preview was released:
https://techcommunity.microsoft.com/t5/exchange-team-blog/the-microsoft-hybrid-agent-public-preview/ba-p/608939

But then in the April update multiagent capability was added and the option was added even if it's not the first time you run the HCW:
https://techcommunity.microsoft.com/t5/exchange-team-blog/microsoft-hybrid-agent-preview-update/ba-p/609351
If it's not available, how can you install additional agents running the HCW?

Also, tested it in an existing Exchange 2016 hybrid deployment to confirm:
![image](https://user-images.githubusercontent.com/33589238/88799951-b1a94880-d17d-11ea-91c3-a9d50fc4e0cf.png)

Closes https://github.com/MicrosoftDocs/OfficeDocs-Exchange/issues/1756.