### PR TITLE
Update site-mailboxes.md

### DIFF
--- a/Exchange/ExchangeServer/collaboration/site-mailboxes.md
+++ b/Exchange/ExchangeServer/collaboration/site-mailboxes.md
@@ -30,10 +30,6 @@ Site mailboxes require Exchange 2016 or later and SharePoint Server 2013 or late
 
 For more information about collaboration features in Exchange Server, see [Collaboration](collaboration.md).
 
->[!NOTE]
-> The site mailboxes are being retired and will be out of service and/or removed.
-
-For more information see, [Retirement of site mailboxes](https://docs.microsoft.com/sharepoint/deprecation-of-site-mailboxes).
 
 ## How do site mailboxes work?
 <a name="howwork"> </a>


### PR DESCRIPTION
The following note and article link is specific to EXO, not applicable to Exchange On-Premises. We will need to provide separate guidance for On-Premises site mailbox deprecation

>[!NOTE]
> The site mailboxes are being retired and will be out of service and/or removed.

For more information see, [Retirement of site mailboxes](https://docs.microsoft.com/sharepoint/deprecation-of-site-mailboxes).