### PR TITLE
Update-Recover-Server

### DIFF
--- a/Exchange/ExchangeServer/high-availability/disaster-recovery/recover-exchange-servers.md
+++ b/Exchange/ExchangeServer/high-availability/disaster-recovery/recover-exchange-servers.md
@@ -50,7 +50,8 @@ Looking for other management tasks related to backing up and restoring data? Che
 
    4. Find the **msExchInstallPath** attribute. This attribute stores the current installation path.
 
-- If you do not have the installation media for the Cumulative Update (CU) version that was installed on the server to be recovered, you can recover a server using the latest available Cumulative Update. Only the last two CUs are available for download. For more information, see [Updates for Exchange Server](../../new-features/updates.md).
+- If you do not have the installation media for the Cumulative Update (CU) version that was installed on the server to be recovered, you can recover a server using the latest available Cumulative Update. Only the last two CUs are available for download. For more information, see [Updates for Exchange Server](../../new-features/updates.md). 
+Once the upgrade is successful, AdminDisplayVersion in EMS or msExchVersion attribute on recovered server will show old build number and this is a cosmetic in nature. We can either run setup /m:upgrade /IAcceptEchangeServerLicenseTerms  or wait for next Cumulative Update release and perform the upgrade which will correct this.
 
 - The target server must use the same version of Windows Server as the lost server. For example, you can't recover a lost Exchange 2016 server that was running Windows 2012 R2 on a new server that's running Windows 2016, or vice-versa.
 


### PR DESCRIPTION
If you do not have the installation media for the Cumulative Update (CU) version that was installed on the server to be recovered, you can recover a server using the latest available Cumulative Update. Only the last two CUs are available for download. For more information, see Updates for Exchange Server.

This statement might need some correction. We are able to complete the recovery but the AdminDisplayVersion is not getting updated during the recovery task and customer will see a cosmetic issue with incorrect build version in AD for Exchange Server configuration object. Doing an Upgrade using the same CU i.e. setup /IAcceptExchangeServerLicenseTerms /m:upgrade fixes this issue or customer can wait for the next CU and perform an upgrade to get this updated to latest version.

Comparing the recover server task and upgrade task I could find we do not do the following tasks:

# Tasks for 'Provision Server' component
# [ID = ProvisionServerComponent___84489810458648f5ac6e47811394a284, Wt = 1, isFatal = True] "Provisioning the Exchange server object"
12/2/2020 9:57:22 AM:upgrade-ExchangeServer -Identity $RoleFqdnOrName -DomainController $RoleDomainController
# [ID = ProvisionServerComponent___49c64f11a4174d48a5a2eed060225271, Wt = 1, isFatal = True] "Provisioning the Exchange server object"
12/2/2020 9:57:22 AM:
          if ($server -eq $null)
          {
          Add-RoutingGroupMember -DomainController $RoleDomainController -ServerName $RoleNetBIOSName
          }
# [ID = ProvisionServerComponent___cff4878349854618beeb2c9e17cc5214, Wt = 1, isFatal = True] "Provisioning the Exchange server object"
12/2/2020 9:57:23 AM:
          if ( ($server -eq $null) -and ($RoleIsDatacenter -ne $true) )
          {
            Update-RmsSharedIdentity -ServerName $RoleNetBIOSName
          }

And this is where we update the AdminDisplayVersion

We can update it to something like this:

If you do not have the installation media for the Cumulative Update (CU) version that was installed on the server to be recovered, you can recover a server using the latest available Cumulative Update. Only the last two CUs are available for download. For more information, see [Updates for Exchange Server](../../new-features/updates.md). 
Once the upgrade is successful, AdminDisplayVersion in EMS or msExchVersion attribute on recovered server will show old build number and this is a cosmetic in nature. We can either run setup /m:upgrade /IAcceptEchangeServerLicenseTerms  or wait for next Cumulative Update release and perform the upgrade which will correct this.