### PR TITLE
SIR does not retain COW items instead Litigation Hold.

### DIFF
--- a/Exchange/ExchangeServer2013/enable-or-disable-single-item-recovery-exchange-2013-help.md
+++ b/Exchange/ExchangeServer2013/enable-or-disable-single-item-recovery-exchange-2013-help.md
@@ -15,7 +15,7 @@ mtps_version: v=EXCHG.150
 
 _**Applies to:** Exchange Server 2013_
 
-You can use the Shell to enable or disable single item recovery on a mailbox. In Exchange Server, single item recovery is disabled when a mailbox is created. If single item recovery is enabled, messages that are permanently deleted (purged) by the user are retained in the Recoverable Items folder of the mailbox until the deleted item retention period expires. This lets an administrator recover messages purged by the user before the deleted item retention period expires. Also, if a message is changed by a user or a process, copies of the original item are also retained when single item recovery is enabled.
+You can use the Shell to enable or disable single item recovery on a mailbox. In Exchange Server, single item recovery is disabled when a mailbox is created. If single item recovery is enabled, messages that are permanently deleted (purged) by the user are retained in the Recoverable Items folder of the mailbox until the deleted item retention period expires. This lets an administrator recover messages purged by the user before the deleted item retention period expires. Also, if a message is changed by a user or a process, copies of the original item are also retained when single item recovery and Litigation Hold both are enabled.
 
 ## What do you need to know before you begin?
 


### PR DESCRIPTION
Here is the statement from the article:
Also, if a message is changed by a user or a process, copies of the original item are also retained when single item recovery is enabled. 

Here is what we need to update:
Also, if a message is changed by a user or a process, copies of the original item are also retained when single item recovery and Litigation Hold both are enabled.

This is applicable for both Exchange Server 2013, 2016, 2019 and Exchange Online. All reference articles for Single Item Recovery needs to be updated for related products.