### PR TITLE
Clarifying and url fix

### DIFF
--- a/Exchange/ExchangeOnline/mailbox-migration/perform-G-Suite-migration.md
+++ b/Exchange/ExchangeOnline/mailbox-migration/perform-G-Suite-migration.md
@@ -156,12 +156,13 @@ If your project doesn't already have all of the required APIs enabled, you must 
 
 2. Click **Domains**, then **Manage domains**, and then click **Add a domain**.
 
+   > [!NOTE]
+   > The option _Add a domain_ will not be available if using the legacy free edition of G Suite. 
+
 3. Enter the domain that you will use for routing mails to Microsoft 365 or Office 365, then click **Continue and verify domain ownership**. A subdomain of your primary domain is recommended (such as "o365.fabrikaminc.net" when "fabrikaminc.net" is your primary domain) so that it will be automatically verified. Keep track of the name of the domain you enter because you will need it for the following steps, and later in the instructions as the Target Delivery Domain when you [Create a migration batch in Microsoft 365 or Office 365](#create-a-migration-batch-in-microsoft-365-or-office-365).
 
    > [!NOTE]
    > A sub-domain of your primary domain is recommended. If another domain (such as "fabrikaminc.onmicrosoft.com") is set, Google will send emails to each individual address with a link to verify the permission to route mail. Migration won't complete until the verification is completed.
-   >
-   > The option to Add a domain will not be available if using the legacy free edition of G Suite. 
 
    ![Add domain](../media/add-a-new-domain-im8.png)
 

--- a/Exchange/ExchangeOnline/mailbox-migration/perform-G-Suite-migration.md
+++ b/Exchange/ExchangeOnline/mailbox-migration/perform-G-Suite-migration.md
@@ -61,7 +61,7 @@ After all migration batches have been completed, all users can use their migrate
 ## Migration limitations
 
 > [!NOTE]
-> The largest single email message that can be migrated is based on the transport configuration for your configuration. The default limit is 35 MB. To increase this limit, see [Office 365 now supports larger email messages](https://www.microsoft.com/microsoft-365/blog/2015/04/15/office-365-now-supports-larger-email-messages-up-to-150-mb/).
+> The largest single email message that can be migrated is based on the transport configuration for your configuration. The default limit is 35 MB. To increase this limit, see [Office 365 now supports larger email messages](https://www.microsoft.com/en-us/microsoft-365/blog/2015/04/15/office-365-now-supports-larger-email-messages-up-to-150-mb/).
 
 Throughput limitations for contacts and calendars completely depend on the quota restrictions for your tenant's service account on the Google Workspace side.
 
@@ -160,6 +160,8 @@ If your project doesn't already have all of the required APIs enabled, you must 
 
    > [!NOTE]
    > A sub-domain of your primary domain is recommended. If another domain (such as "fabrikaminc.onmicrosoft.com") is set, Google will send emails to each individual address with a link to verify the permission to route mail. Migration won't complete until the verification is completed.
+   >
+   > The option to Add a domain will not be available if using the legacy free edition of G Suite. 
 
    ![Add domain](../media/add-a-new-domain-im8.png)
 


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/OfficeDocs-Exchange/issues/2491

Source of the note https://support.google.com/a/answer/7502379?visit_id=637496235003641124-1267497588&rd=1#zippy=%2Cadd-a-secondary-domain-manage-teams-at-different-domains

The url is replaced with the en-us path because that is the only link that works (language redir does not work for other languages)

@dariomws Kindly review