### PR TITLE
update recoverable items sub folders to Teams

### DIFF
--- a/Exchange/ExchangeOnline/security-and-compliance/recoverable-items-folder/recoverable-items-folder.md
+++ b/Exchange/ExchangeOnline/security-and-compliance/recoverable-items-folder/recoverable-items-folder.md
@@ -77,7 +77,7 @@ The Recoverable Items folder contains the following subfolders:
 
 - **Calendar Logging**: This subfolder contains calendar changes that occur within a mailbox. This folder isn't available to users.
 
-- **SubstrateHolds**: If In-Place Hold, Litigation Hold, or a Microsoft 365 or Office 365 Teams Chat retention policy is enabled, this subfolder contains the original copy of the teams message if the message has been modified or deleted. A copy of the item before modification is saved. This folder isn't visible to end users.
+- **SubstrateHolds**: If In-Place Hold, Litigation Hold, or a Microsoft 365 or Office 365 Teams Chat retention policy is enabled, this subfolder contains the original copy of the Teams message if the message has been modified or deleted. A copy of the item before modification is saved. This folder isn't visible to end users.
 
 
 

--- a/Exchange/ExchangeOnline/security-and-compliance/recoverable-items-folder/recoverable-items-folder.md
+++ b/Exchange/ExchangeOnline/security-and-compliance/recoverable-items-folder/recoverable-items-folder.md
@@ -77,6 +77,10 @@ The Recoverable Items folder contains the following subfolders:
 
 - **Calendar Logging**: This subfolder contains calendar changes that occur within a mailbox. This folder isn't available to users.
 
+- **SubstrateHolds**: If In-Place Hold, Litigation Hold, or a Microsoft 365 or Office 365 Teams Chat retention policy is enabled, this subfolder contains the original copy of the teams message if the message has been modified or deleted. A copy of the item before modification is saved. This folder isn't visible to end users.
+
+
+
 The following illustration shows the subfolders in the Recoverable Items folders. It also shows the deleted item retention, single item recovery, and hold workflow processes that are described in the following sections.
 
 ![Recoverable Items folder](../../media/ITPro_RecoverableItems.gif)


### PR DESCRIPTION
New folder in recoverable items to hold chat messages if edited or deleted. 

https://docs.microsoft.com/en-us/microsoft-365/compliance/retention-policies-teams?view=o365-worldwide#how-retention-works-with-microsoft-teams