### PR TITLE
Additional detail about Centralized Mail transport

### DIFF
--- a/Exchange/ExchangeHybrid/transport-options.md
+++ b/Exchange/ExchangeHybrid/transport-options.md
@@ -37,7 +37,7 @@ You'll need to choose how to route inbound and outbound mail when you plan and c
 
 - Do you want to route outbound mail to external recipients from your Exchange Online organization through your on-premises organization (centralized mail transport), or do you want to route it directly to the Internet?
 
-    With centralized mail transport, you can route all mail from mailboxes in the Exchange Online organization through the on-premises organization before they're delivered to the Internet. The same way, incoming Internet messages will be routed to On-premises organization before being delivered to any Exchange On line recipient. Possible scenarios are detailed in Transport Routing in Exchange Hybrid deployments.
+    With centralized mail transport, you can route all mail from mailboxes in the Exchange Online organization through the on-premises organization before they're delivered to the Internet. In the same way, incoming Internet messages will be routed to an on-premises organization before being delivered to any Exchange Online recipient. Possible scenarios are detailed in [Transport routing in Exchange hybrid deployments](https://docs.microsoft.com/microsoft-365/compliance/sensitive-information-type-entity-definitions?view=o365-worldwide).
 This approach is helpful in compliance scenarios where all mail to and from the Internet must be processed by on-premises servers. Alternately, you can configure Exchange Online to deliver messages for external recipients directly to the Internet.
 
     > [!NOTE]

--- a/Exchange/ExchangeHybrid/transport-options.md
+++ b/Exchange/ExchangeHybrid/transport-options.md
@@ -37,10 +37,11 @@ You'll need to choose how to route inbound and outbound mail when you plan and c
 
 - Do you want to route outbound mail to external recipients from your Exchange Online organization through your on-premises organization (centralized mail transport), or do you want to route it directly to the Internet?
 
-    With centralized mail transport, you can route all mail from mailboxes in the Exchange Online organization through the on-premises organization before they're delivered to the Internet. This approach is helpful in compliance scenarios where all mail to and from the Internet must be processed by on-premises servers. Alternately, you can configure Exchange Online to deliver messages for external recipients directly to the Internet.
+    With centralized mail transport, you can route all mail from mailboxes in the Exchange Online organization through the on-premises organization before they're delivered to the Internet. The same way, incoming Internet messages will be routed to On-premises organization before being delivered to any Exchange On line recipient. Possible scenarios are detailed in Transport Routing in Exchange Hybrid deployments.
+This approach is helpful in compliance scenarios where all mail to and from the Internet must be processed by on-premises servers. Alternately, you can configure Exchange Online to deliver messages for external recipients directly to the Internet.
 
     > [!NOTE]
-    > Centralized mail transport is only recommended for organizations with specific compliance-related transport needs. Our recommendation for typical Exchange organizations is not to enable centralized mail transport as it can significantly increase the amount of messages processed by your on-premises servers, increase the bandwidth used, and create an unnecessary dependency on your on-premises servers.
+    > Centralized mail transport is only recommended for organizations with specific compliance-related transport needs. Our recommendation for typical Exchange organizations is not to enable centralized mail transport as it can significantly increase the amount of messages processed by your on-premises servers, increase the bandwidth used, and create an unnecessary dependency on your on-premises servers.  
 
 - Do you want to deploy an Edge Transport server in your on-premises organization?
 


### PR DESCRIPTION
The article says "you can route all mail from mailboxes in Exchange online" but the emails coming form internet will be routed to on-premises as well, if centralized mail flow is enabled. I've added the additional information there. 

Technical reference: 
https://docs.microsoft.com/en-us/exchange/transport-routing#inbound-messages-from-the-internet