### PR TITLE
Update manage-dynamic-distribution-groups.md

### DIFF
--- a/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-dynamic-distribution-groups/manage-dynamic-distribution-groups.md
+++ b/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-dynamic-distribution-groups/manage-dynamic-distribution-groups.md
@@ -122,7 +122,7 @@ Unlike regular distribution groups that contain a defined set of members, the me
 
    - **Only the following recipient types**: Messages that meet the criteria defined for this group will be sent to one or more of the following recipient types:
 
-   - **Users with Exchange mailboxes**: Select this check box if you want to include users that have Exchange mailboxes. Users that have Exchange mailboxes are those that have a user domain account and a mailbox in the Exchange organization.
+   - **Users with Exchange mailboxes**: Select this check box if you want to include users that have Exchange mailboxes. Users that have Exchange mailboxes are those that have a user domain account and a mailbox in the Exchange organization. Note that resource mailboxes are also included.
 
    - **Users with external email addresses**: Select this check box if you want to include users that have external email addresses. Users that have external email accounts have user domain accounts in Active Directory, but use email accounts that are external to the organization. This enables them to be included in the global address list (GAL) and added to distribution lists.
 


### PR DESCRIPTION
Admins can be confused and misunderstand "Users with Exchange mailboxes" and "Resource mailboxes" filter. 
They may think the "Users with Exchange mailboxes" only contains accounts with RecipientTypeDetails as UserMailbox, and only the "Resource mailboxes" option filters resource mailboxes.
However the fact is "Users with Exchange mailboxes" option also contains resources mailboxes.
It is better that this potential misunderstanding can be mentioned in document.