### PR TITLE
Update retention-tags-and-policies.md

### DIFF
--- a/Exchange/ExchangeOnline/security-and-compliance/messaging-records-management/retention-tags-and-policies.md
+++ b/Exchange/ExchangeOnline/security-and-compliance/messaging-records-management/retention-tags-and-policies.md
@@ -192,3 +192,6 @@ During long absences from work, users may accrue a large amount of e-mail. Depen
 If your organization has never implemented MRM, and your users aren't familiar with its features, you can also use retention holds during the initial warm up and training phase of your MRM deployment. You can create and deploy retention policies and educate users about the policies without the risk of having items moved or deleted before users can tag them. A few days before the warm up and training period ends, you should remind users of the warm-up deadline. After the deadline, you can remove the retention hold from user mailboxes, allowing the Managed Folder Assistant to process mailbox items and take the specified retention action.
 
 For details about how to place a mailbox on retention hold, see [Place a mailbox on retention hold](mailbox-retention-hold.md).
+
+This test will check and validate the retention policy settings configured for the user;
+	[Run Tests: Retention Policy](https://aka.ms/PillarRetentionPolicy)


### PR DESCRIPTION
@chrisda, we are starting to add deep links for inline diagnostic to articles for self-help.  Can we add the following at the bottom of this article:

This test will check and validate the retention policy settings configured for the user;
	[Run Tests: Retention Policy](https://aka.ms/PillarRetentionPolicy)


It should be similar to the diagnostic link in this article :https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/use-dkim-to-validate-outbound-email?view=o365-worldwide