### PR TITLE
Correct indentation & appearance of a note

### DIFF
--- a/Exchange/ExchangeOnline/mailbox-migration/migrating-imap-mailboxes/prepare-gmail-or-g-suite-accounts.md
+++ b/Exchange/ExchangeOnline/mailbox-migration/migrating-imap-mailboxes/prepare-gmail-or-g-suite-accounts.md
@@ -37,8 +37,8 @@ manager: serdars
 
 # Prepare your Gmail or Google Workspace (formerly G Suite) account for connecting to Outlook and Microsoft 365 or Office 365
 
-    > [!IMPORTANT]
-    > The ability to add new accounts to Outlook on the web using the Connected accounts feature was removed in September 2018.
+> [!IMPORTANT]
+> The ability to add new accounts to Outlook on the web using the Connected accounts feature was removed in September 2018.
     
 Before you [connect to your Gmail](https://support.microsoft.com/office/d7012ff0-924f-4f78-8aca-c3912d886c4d) account from Outlook on the web, or [add a Gmail](https://support.microsoft.com/office/6e27792a-9267-4aa4-8bb6-c84ef146101b) account to Outlook, you need to prepare your Gmail account. You need to turn on 2-step verification for Gmail and then create an app password that Office 365 will use with your Gmail address to make the connection.
 


### PR DESCRIPTION
@get-itips
This PR corrects the indentation of a note and, thereby, corrects the rendering of the note. Notes must be aligned on the left with the text of the preceding line to which they pertain. Since this note immediately follows a heading, it should have no indentation. Since it did have indentation when it was added in PR https://github.com/MicrosoftDocs/OfficeDocs-Exchange/pull/2896, it was rendered as a code block:

![image](https://user-images.githubusercontent.com/5432776/146467861-25004d85-b452-44e6-be4c-bfba80f31583.png)
