### PR TITLE
Fix link to point to EXO instead of Exchange Server 2019 docs

### DIFF
--- a/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-dynamic-distribution-groups/modern-dynamic-distribution-groups.md
+++ b/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-dynamic-distribution-groups/modern-dynamic-distribution-groups.md
@@ -53,7 +53,7 @@ Get-DynamicDistributionGroupMember -Identity <DDGIdentity>
 For detailed parameter and syntax information, see [Get-DynamicDistributionGroupMember](/powershell/module/exchange/get-dynamicdistributiongroupmember).
 
 > [!NOTE]
-> Do not use the [old procedure](/exchange/recipients-in-exchange-online/manage-dynamic-distribution-groups/view-group-members) for viewing members of a DDG. The old procedure only evaluates the users that satisfy the DDG filters at the time you run the old procedure. The old procedure doesn't return the calculated list of members that's stored on the DDG object.
+> Don't use the old procedure for viewing members of a DDG as described in [View members of a dynamic distribution group in Exchange Online](/exchange/recipients-in-exchange-online/manage-dynamic-distribution-groups/view-group-members). The old procedure returns all users that satisfy the DDG filters at the time you run the command. The old procedure does not return the calculated list of members that are stored on the DDG object.
 
 ## Refresh the membership of a DDG
 

--- a/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-dynamic-distribution-groups/modern-dynamic-distribution-groups.md
+++ b/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-dynamic-distribution-groups/modern-dynamic-distribution-groups.md
@@ -53,7 +53,7 @@ Get-DynamicDistributionGroupMember -Identity <DDGIdentity>
 For detailed parameter and syntax information, see [Get-DynamicDistributionGroupMember](/powershell/module/exchange/get-dynamicdistributiongroupmember).
 
 > [!NOTE]
-> Do not use the [old procedure](/exchange/recipients/dynamic-distribution-groups/view-dynamic-distribution-group-members) for viewing members of a DDG. The old procedure only evaluates the users that satisfy the DDG filters at the time you run the old procedure. The old procedure doesn't return the calculated list of members that's stored on the DDG object.
+> Do not use the [old procedure](/exchange/recipients-in-exchange-online/manage-dynamic-distribution-groups/view-group-members) for viewing members of a DDG. The old procedure only evaluates the users that satisfy the DDG filters at the time you run the old procedure. The old procedure doesn't return the calculated list of members that's stored on the DDG object.
 
 ## Refresh the membership of a DDG
 


### PR DESCRIPTION
The link to the old procedure to view dynamic distribution group members points to Exchange Server 2019 docs. Since this applies to Exchange Online, the proposed change fixes the link to the appropriate version.