### PR TITLE
Update supportability-matrix.md

### DIFF
--- a/Exchange/ExchangeServer/plan-and-deploy/supportability-matrix.md
+++ b/Exchange/ExchangeServer/plan-and-deploy/supportability-matrix.md
@@ -197,6 +197,7 @@ The following tables identify the mail clients that are supported for use togeth
 |Client|Exchange 2019|Exchange 2016|Exchange 2013 SP1 and later|Exchange 2010 SP3|
 |---|:---:|:---:|:---:|:---:|
 |Microsoft 365 Apps for enterprise|Supported|Supported|Supported|Not supported|
+|Outlook 2021|Supported|Supported|Not supported|Not supported|
 |Outlook 2019|Supported|Supported|Supported|Not supported|
 |Outlook 2016|Supported<sup>1</sup>|Supported<sup>1</sup>|Supported|Supported|
 |Outlook 2013|Supported<sup>1</sup>|Supported<sup>1</sup>|Supported|Supported|


### PR DESCRIPTION
Per discussion with Outlook PG Jenna Lyday; Martin Calsyn we are updating the support matrix to show that Outlook 2021 is supported with Exchange 2016 and higher.