### PR TITLE
Update system-requirements.md

### DIFF
--- a/Exchange/ExchangeServer/plan-and-deploy/system-requirements.md
+++ b/Exchange/ExchangeServer/plan-and-deploy/system-requirements.md
@@ -141,6 +141,7 @@ We strongly recommend that you use the latest version of the .NET Framework that
 ## Supported clients (with latest updates) in Exchange 2019
 
 - Microsoft 365 Apps for enterprise
+- Outlook 2021
 - Outlook 2019
 - Outlook 2016
 - Outlook 2013


### PR DESCRIPTION
Per discussion with Outlook PG Jenna Lyday and Martin Calsyn we are noting that Outlook 2021 is supported with Exchange 2019.