### PR TITLE
Correct permissions

### DIFF
--- a/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-user-mailboxes/recover-deleted-messages.md
+++ b/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-user-mailboxes/recover-deleted-messages.md
@@ -67,7 +67,7 @@ For instructions, see [Connect to Exchange Online PowerShell](/powershell/exchan
 
 ### Step 2: Search for and recover missing items
 
-You need permissions before you can do this procedure or procedures. To see what permissions you need, see the "In-Place eDiscovery" entry in the [Feature permissions in Exchange Online](../../permissions-exo/feature-permissions.md) article.
+You need _Mailbox Import Export_ RBAC role before you can do this procedure or procedures.
 
 > [!NOTE]
 > You can use In-Place eDiscovery in the Exchange admin center (EAC) to search for missing items. However, when using the EAC, you can't restrict the search to the Recoverable Items folder. Messages matching your search parameters will be returned even if they're not deleted. After they're recovered to the specified discovery mailbox, you may need to review the search results and remove unnecessary messages before recovering the remaining messages to the user's mailbox or exporting them to a .pst file. For details about how to use the EAC to perform an In-Place eDiscovery search, see [Create an In-Place eDiscovery search](/microsoft-365/compliance/content-search).
@@ -90,7 +90,7 @@ To verify that you have successfully searched the messages you want to recover, 
 
 ### Step 3: Restore recovered items
 
-You need permissions before you can do this procedure or procedures. To see what permissions you need, see the "In-Place eDiscovery" entry in the [Feature permissions in Exchange Online](../../permissions-exo/feature-permissions.md) article.
+You need _Mailbox Import Export_ RBAC role before you can do this procedure or procedures.
 
 > [!NOTE]
 > You can't use the EAC to restore recovered items.

--- a/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-user-mailboxes/recover-deleted-messages.md
+++ b/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-user-mailboxes/recover-deleted-messages.md
@@ -90,7 +90,7 @@ To verify that you have successfully searched the messages you want to recover, 
 
 ### Step 3: Restore recovered items
 
-You need _Mailbox Import Export_ RBAC role before you can do this procedure or procedures.
+You need the _Mailbox Import Export_ RBAC role before you can do this procedure or procedures.
 
 > [!NOTE]
 > You can't use the EAC to restore recovered items.

--- a/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-user-mailboxes/recover-deleted-messages.md
+++ b/Exchange/ExchangeOnline/recipients-in-exchange-online/manage-user-mailboxes/recover-deleted-messages.md
@@ -67,7 +67,7 @@ For instructions, see [Connect to Exchange Online PowerShell](/powershell/exchan
 
 ### Step 2: Search for and recover missing items
 
-You need _Mailbox Import Export_ RBAC role before you can do this procedure or procedures.
+You need the _Mailbox Import Export_ RBAC role before you can do this procedure or procedures.
 
 > [!NOTE]
 > You can use In-Place eDiscovery in the Exchange admin center (EAC) to search for missing items. However, when using the EAC, you can't restrict the search to the Recoverable Items folder. Messages matching your search parameters will be returned even if they're not deleted. After they're recovered to the specified discovery mailbox, you may need to review the search results and remove unnecessary messages before recovering the remaining messages to the user's mailbox or exporting them to a .pst file. For details about how to use the EAC to perform an In-Place eDiscovery search, see [Create an In-Place eDiscovery search](/microsoft-365/compliance/content-search).


### PR DESCRIPTION
closes https://github.com/MicrosoftDocs/OfficeDocs-Exchange/issues/3159

source https://techcommunity.microsoft.com/t5/exchange-team-blog/a-new-recoverableitems-experience-comes-to-exchange-online/ba-p/1505353

"Admins must manually add the Mailbox Import Export RBAC role to accounts they wish to use the Recover Deleted Items feature with."

and also tested, Discovery Management is not enough to see the recover deleted items option in the EAC and to use the cmdlets, removing also the link to an article that does not mention this.